### PR TITLE
preemptの指定を可能にする

### DIFF
--- a/recipes/vrrp_instances.rb
+++ b/recipes/vrrp_instances.rb
@@ -15,7 +15,7 @@ Array(node['keepalived']['vrrp_instances']).each do |name, instance|
     garp_master_delay (instance[:garp_master_delay] || defaults[:garp_master_delay]).to_i
     advert_int (instance[:advert_int] || defaults[:advert_int]).to_i
     state (instance[:states][node.name] || defaults[:state]).to_sym
-    nopreempt if instance[:nopreempt]
+    nopreempt (true) if instance[:nopreempt]
     priority (instance[:priorities][node.name] || defaults[:priority]).to_i
     virtual_ip_addresses instance[:virtual_ip_addresses]
 


### PR DESCRIPTION
`recipes/vrrp_instances.rb`において、`nopreempt`が`true`指定されていても、templateに`true`が与えられない不具合の修正。