### PR TITLE
Allow to set notify_xxxx on vrrp_instance

### DIFF
--- a/providers/vrrp_instance.rb
+++ b/providers/vrrp_instance.rb
@@ -47,7 +47,7 @@ action :create do
         'virtual_ip_addresses' => new_resource.virtual_ip_addresses,
         'options' => options
       )
-      notifies :restart, 'service[keepalived]'
+      notifies :reload, 'service[keepalived]'
     end
   end
 end

--- a/providers/vrrp_sync_group.rb
+++ b/providers/vrrp_sync_group.rb
@@ -37,7 +37,7 @@ action :create do
         'group' => new_resource.group,
         'options' => options
       )
-      notifies :restart, 'service[keepalived]'
+      notifies :reload, 'service[keepalived]'
     end
   end
 end

--- a/templates/default/vrrp_instance.conf.erb
+++ b/templates/default/vrrp_instance.conf.erb
@@ -29,4 +29,13 @@ vrrp_instance <%= @name.upcase %> {
     <% end %>
   }
   <% end -%>
+  <% if @options['notify_backup'] -%>
+  notify_backup "<%= @options['notify_backup'] %>"
+  <% end -%>
+  <% if @options['notify_master'] -%>
+  notify_master "<%= @options['notify_master'] %>"
+  <% end -%>
+  <% if @options['notify_fault'] -%>
+  notify_fault "<%= @options['notify_fault'] %>"
+  <% end -%>
 }


### PR DESCRIPTION
`keepalived_vrrp_instance` resource can receive `notify_master` option but not apply actual config.